### PR TITLE
add env as an available backend

### DIFF
--- a/libraries/confd_config.rb
+++ b/libraries/confd_config.rb
@@ -22,7 +22,7 @@ module ConfdCookbook
 
       attribute(:auth_token, kind_of: String)
       attribute(:onetime, equal_to: [true, false], default: lazy { default_onetime })
-      attribute(:backend, equal_to: %w{consul dynamodb etcd redis zookeeper}, required: true)
+      attribute(:backend, equal_to: %w{consul dynamodb etcd redis zookeeper env}, required: true)
       attribute(:client_cakeys, kind_of: String)
       attribute(:client_cert, kind_of: String)
       attribute(:client_key, kind_of: String)


### PR DESCRIPTION
Adds `env` as an available backend for the `confd_config` resource.